### PR TITLE
Elixir Implementation Example + Readme Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The files in this repository are examples and not guaranteed to run or be correc
 
 ## Documentation
 
-Further documentation on JWT based Zendesk SSO is available [in our knowledge base](https://support.zendesk.com/entries/23675367)
+Further documentation on JWT based Zendesk SSO is available [in our knowledge base](https://support.zendesk.com/hc/en-us/articles/4408845838874-Enabling-JWT-JSON-Web-Token-single-sign-on)
 
 ## Contributing
 
@@ -12,7 +12,7 @@ Examples and improvements much appreciated.
 
 ### License
 
-Copyright 2013 Zendesk
+Copyright 2022 Zendesk
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/elixir.ex
+++ b/elixir.ex
@@ -1,0 +1,55 @@
+defmodule ZendeskSso do
+  # assumes you have the Joken JWT module:
+  # https://github.com/joken-elixir/joken
+
+  # assumes you have the UUID module:
+  # https://hexdocs.pm/uuid/readme.html
+
+  use Joken.Config
+
+  def generate_zendesk_jwt_token(%User{} = user) do
+    zendesk_config = Application.get_env(:zendesk)
+    jwt_secret = Keyword.get(zendesk_config, :jwt_secret)
+    algorithm = Keyword.get(zendesk_config, :algorithm)
+
+    signer = Joken.Signer.create(algorithm, jwt_secret)
+
+    jwt_params = %{
+      iat: DateTime.utc_now(),
+      jit: UUID.uuid4(),
+      email: user.email,
+      name: user.name
+    }
+
+    generate_and_sign!(jwt_params, signer)
+  end
+
+  # this assumes the session is already authenticated
+  def authenticate_zendesk(conn, _params) do
+    zendesk_config = Application.get_env(:zendesk)
+    zendesk_subdomain = Keyword.get(zendesk_config, :subdomain)
+
+    jwt_user_token = generate_zendesk_jwt_token(user)
+
+    return_to =
+      params
+      |> Map.get("return_to", nil)
+      |> case do
+        nil ->
+          nil
+
+        return_to ->
+          URI.encode_query(return_to)
+      end
+
+    redirect_location =
+      "https://#{zendesk_subdomain}.zendesk.com/access/jwt?jwt=#{jwt_user_token}"
+
+    redirect_location =
+      if is_nil(return_to),
+        do: redirect_location,
+        else: "#{redirect_location}&return_to=#{return_to}"
+
+    redirect(conn, external: redirect_location)
+  end
+end

--- a/elixir.ex
+++ b/elixir.ex
@@ -25,7 +25,7 @@ defmodule ZendeskSso do
   end
 
   # this assumes the session is already authenticated
-  def authenticate_zendesk(conn, _params) do
+  def authenticate_zendesk(conn, params) do
     zendesk_config = Application.get_env(:zendesk)
     zendesk_subdomain = Keyword.get(zendesk_config, :subdomain)
 


### PR DESCRIPTION
## Changes
- Add an Elixir example for implementation of Zendesk JWT Authentication
- Update Readme for link to documentation on how to implement (outdated link), and update the outdated copyright year